### PR TITLE
Ensure that Make Clean also deletes romfs.bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ $(BUILD):
 clean:
 	@echo clean ...
 	@rm -fr $(BUILD) $(TARGET).3dsx $(OUTPUT).smdh $(TARGET).elf $(TARGET)-strip.elf $(TARGET).cia $(TARGET).3ds
+	@rm -fr romfs.bin
 #---------------------------------------------------------------------------------
 $(TARGET)-strip.elf: $(BUILD)
 	@$(STRIP) $(TARGET).elf -o $(TARGET)-strip.elf


### PR DESCRIPTION
I might be wrong here and in that case feel free to reject this pull request, but previously a `make clean` wouldn't wipe the `romfs.bin` so I added a line for that. Seeing as what the romfs is I _assume_ it makes sense to delete that as well with the `make clean`.